### PR TITLE
Chainmap refactor

### DIFF
--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -2,14 +2,12 @@ import yaml
 
 from helpers.logHelpers import createLog
 
-
 logger = createLog('configHelpers')
 
 
 def loadEnvFile(runType, fileString):
 
     envDict = None
-    fileLines = []
 
     if fileString:
         openFile = fileString.format(runType)
@@ -24,13 +22,11 @@ def loadEnvFile(runType, fileString):
                 logger.error('{} Invalid! Please review'.format(openFile))
                 raise err
 
-            envStream.seek(0)
-            fileLines = envStream.readlines()
-
     except FileNotFoundError as err:
         logger.info('Missing config YAML file! Check directory')
         logger.debug(err)
 
     if envDict is None:
-        envDict = {}
-    return envDict, fileLines
+        return {}
+    
+    return envDict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,31 +9,31 @@ class TestConfig(unittest.TestCase):
 
     @patch('yaml.load', return_value={'testing': True})
     def test_load_env_success(self, mock_yaml):
-        resDict, resLines = loadEnvFile('development', None)
+        resDict = loadEnvFile('development', None)
         self.assertTrue(resDict['testing'])
 
     @patch('yaml.load', return_value={'testing': True})
     def test_load_env_config_success(self, mock_yaml):
-        resDict, resLines = loadEnvFile('development', 'config/{}.yaml')
+        resDict = loadEnvFile('development', 'config/{}.yaml')
         self.assertTrue(resDict['testing'])
 
     @patch('yaml.load', side_effect={'testing': True})
     def test_load_env_failure(self, mock_yaml):
         try:
-            resDict, resLines = loadEnvFile('development', 'missing/{}.yaml')
+            resDict = loadEnvFile('development', 'missing/{}.yaml')
         except FileNotFoundError:
             pass
         self.assertRaises(FileNotFoundError)
 
     @patch('yaml.load', return_value=None)
     def test_load_empty_env(self, mock_yaml):
-        resDict, resLines = loadEnvFile('development', None)
+        resDict = loadEnvFile('development', None)
         self.assertEqual(resDict, {})
 
     @patch('yaml.load', side_effect=YAMLError)
     def test_read_env_failure(self, mock_yaml):
         try:
-            resDict, resLines = loadEnvFile('development', 'config/{}.yaml')
+            resDict = loadEnvFile('development', 'config/{}.yaml')
         except YAMLError:
             pass
         self.assertRaises(YAMLError)


### PR DESCRIPTION
This implements the sequential loading of `yaml` configuration files through the use of `ChainMap` which greatly simplifies the process of combining several configuration files into a single object that can be used to generate a unified configuration for runs/deployments of lambda code.

The use of `Chainmap` allows for two or more configuration files to be loaded, with each subsequent file providing a higher degree of specificity and overwriting previously set variables. In practice this means that a default `config.yaml` file can be in place, and when deployed to development the `development.yaml` file can be used to overwrite the changed settings, allowing for easier management of environments and insight into the differences in configuration.

Overall this update:
- Implements `Chainmap` to allow for better merging of configuration files
- Simplifies the `lambdaRun.py` file accordingly
- Updates the test suite and other code cleanup tasks