### PR TITLE
Add environment variable decryptor

### DIFF
--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -1,3 +1,8 @@
+from base64 import b64decode
+from binascii import Error as base64Error
+import boto3
+from botocore.exceptions import ClientError
+import os
 import yaml
 
 from helpers.logHelpers import createLog
@@ -96,3 +101,24 @@ def setEnvVars(runType):
         logger.error(('Script lacks necessary permissions, '
                       'ensure user has permission to write to directory'))
         raise err
+
+
+def decryptEnvVar(envVar):
+    """This helper method takes a KMS encoded environment variable and decrypts
+    it into a usable value. Sensitive variables should be so encoded so that
+    they can be stored in git and used in a CI/CD environment.
+
+    Arguments:
+        envVar {string} -- a string, either plaintext or a base64, encrypted
+        value
+    """
+    encrypted = os.environ.get(envVar, None)
+
+    try:
+        decoded = b64decode(encrypted)
+        # If region is not set, assume us-east-1
+        regionName = os.environ.get('AWS_REGION', 'us-east-1')
+        return boto3.client('kms', region_name=regionName)\
+            .decrypt(CiphertextBlob=decoded)['Plaintext'].decode('utf-8')
+    except (ClientError, base64Error, TypeError):
+        return encrypted


### PR DESCRIPTION
It is essential that lambda functions be able to read/utilize sensitive environment variables such as database credentials and API keys. This adds a helper function that allows such variables to be encrypted using the AWS KMS service and decoded at runtime.

Using this these variables can be committed to version control and used in a CI/CD pipeline to automate deployments, among other things.

Part of a continued effort to add robust set of helper functions to improve the functionality of this boilerplate and make it more generally useful for developing lambda functions.