### PR TITLE
0.2.1 patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 	python3 -m scripts.lambdaRun build-$(ENV)
 
 test:
-	coverage run -m unittest
+	coverage run -m pytest
 
 coverage-report:
 	coverage report -m

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,0 +1,7 @@
+# Uncomment the below/add additional env variables to add them to the lambda
+runtime: python3.7
+
+# === ENVIRONMENT_VARIABLES ===
+environment_variables:
+    LOG_LEVEL: debug
+    TESTING: HELLO, JERRY

--- a/helpers/clientHelpers.py
+++ b/helpers/clientHelpers.py
@@ -25,7 +25,7 @@ def createAWSClient(service, configDict=None):
         services from the associated AWS service.
     """
     if configDict is None:
-        configDict, configLines = loadEnvFile(None, None)
+        configDict = loadEnvFile(None, None)
 
     clientKwargs = {
         'region_name': configDict['region']

--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -72,7 +72,7 @@ def loadEnvVars(runType):
 
     # Merge the loaded dicts, overwriting any matching settings with the values
     # from the env-specific file.
-    combinedConfig = {**currentEnvDict, **baseConfigDict}
+    combinedConfig = {**baseConfigDict, **currentEnvDict}
 
     return combinedConfig
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ boto3
 python-lambda
 coverage
 flake8
+pytest
 pyyaml

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,7 +36,7 @@ class TestClient(unittest.TestCase):
 
     @patch(
         'helpers.clientHelpers.loadEnvFile',
-        return_value=({'region': 'test'}, None)
+        return_value=({'region': 'test'})
     )
     @patch('boto3.client', return_value=True)
     def test_create_with_load_env(self, mock_boto, mock_env):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ class TestConfig(unittest.TestCase):
         testDict = loadEnvVars('test')
         self.assertIsInstance(testDict, dict)
         self.assertEqual(testDict['test1'], 'hello')
-        self.assertEqual(testDict['test2'], 'jerry')
+        self.assertEqual(testDict['test2'], 'world')
 
     @patch('helpers.configHelpers.loadEnvVars', return_value=mockReturns)
     @patch('builtins.open', new_callable=mock_open, read_data='data')


### PR DESCRIPTION
In the latest release several minor bugs were introduced as the result of new features/improvements. This patch resolves those issues to ensure that all potential uses of the boilerplate function as intended.

Additionally `pytest` is being introduced as the test runner for a cleaner output and better quality-of-life in writing tests.

Fixes
- Reorder variable loading from environment-specific files
- Remove dangling reference to `configLines`
- Add `local.yaml` as it is normally necessary for `make run-local` now